### PR TITLE
feat: Add next-redux-wrapper package

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "dependencies": {
     "@reduxjs/toolkit": "1.9.5",
     "next": "latest",
+    "next-redux-wrapper": "^8.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-redux": "8.1.0"

--- a/src/components/AnotherComponent.tsx
+++ b/src/components/AnotherComponent.tsx
@@ -4,12 +4,10 @@ import store from "../store";
 
 export function AnotherComponent() {
 	useEffect(() => {
-		// setTimeout(() => {
 		if (typeof window !== undefined) {
 			console.log("Dispatched");
 			store.dispatch(fetchCounterDataThunk());
 		}
-		// }, 5000);
 	}, []);
 
 	return "Child Component calls Async Thunk to fetch data and put in store";

--- a/src/pages/_app.page.tsx
+++ b/src/pages/_app.page.tsx
@@ -1,8 +1,13 @@
 import type { AppProps } from "next/app";
 import { Provider } from "react-redux";
-import store from "../store";
+import { wrapper } from "../store";
 
-export default function MyApp({ Component, pageProps }: AppProps) {
+export default function MyApp({ Component, ...rest }: AppProps) {
+	const {
+		store,
+		props: { pageProps },
+	} = wrapper.useWrappedStore(rest);
+
 	return (
 		<Provider store={store}>
 			<Component {...pageProps} />

--- a/src/store.ts
+++ b/src/store.ts
@@ -3,6 +3,7 @@ import { setupListeners } from "@reduxjs/toolkit/query";
 
 import { rootApi } from "./services/rootApi";
 import { counterSliceReducer } from "./slices/counterSlice";
+import { createWrapper } from "next-redux-wrapper";
 
 export const makeStore = () =>
 	configureStore({
@@ -23,3 +24,7 @@ export default store;
 export type AppStoreType = ReturnType<typeof makeStore>;
 export type RootStateType = ReturnType<typeof store.getState>;
 export type AppDispatchType = AppStoreType["dispatch"];
+
+export const wrapper = createWrapper<AppStoreType>(makeStore, {
+	debug: true,
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -202,6 +202,11 @@ nanoid@^3.3.6:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
   integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
 
+next-redux-wrapper@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/next-redux-wrapper/-/next-redux-wrapper-8.1.0.tgz#d9c135f1ceeb2478375bdacd356eb9db273d3a07"
+  integrity sha512-2hIau0hcI6uQszOtrvAFqgc0NkZegKYhBB7ZAKiG3jk7zfuQb4E7OV9jfxViqqojh3SEHdnFfPkN9KErttUKuw==
+
 next@latest:
   version "13.5.4"
   resolved "https://registry.yarnpkg.com/next/-/next-13.5.4.tgz#7e6a93c9c2b9a2c78bf6906a6c5cc73ae02d5b4d"


### PR DESCRIPTION
# Selector not updating when slice data is updated

### Bug Description

1. There is a `Counter` RTK Query Service which has a `getCounter` endpoint that gets the `counter` value from an API (Next.js API for this example repo).

2. There is a slice `counterSlice` that has an async thunk that calls the above query using `counterAPI.endpoints.getCounter.initiate()`

3. `extraReducers` - `builder.addMatcher` are used to update `loading`, `error` and `fulfilled` states in the slice.

4. `AnotherComponent` calls this async thunk using `store.dispatch(fetchCounterDataThunk())`.

5. There is a selector which gets the counter value from the slice defined in `counterSlice` file and used on the `index` page like so `const data = useSelector(getCounter)`.

6. The data updates in the store that can seen via the Redux DevTools, but the selector in the index page does not receive the updated data.

### To see this bug in action head over to [this sandbox](https://codesandbox.io/p/github/karanshah229/next-redux-wrapper-selector-issue/next-redux-wrapper-package?layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clniy640z00d33b6o31tsi5vi%2522%252C%2522sizes%2522%253A%255B70%252C30%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clniy640z00cx3b6o1n80jiml%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clniy640z00d03b6okgd5lt2c%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clniy640z00d23b6oumbd0y88%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B50%252C50%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clniy640z00cx3b6o1n80jiml%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clniy640y00cw3b6oahyxczoe%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252FREADME.md%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%255D%252C%2522id%2522%253A%2522clniy640z00cx3b6o1n80jiml%2522%252C%2522activeTabId%2522%253A%2522clniy640y00cw3b6oahyxczoe%2522%257D%252C%2522clniy640z00d23b6oumbd0y88%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clniy640z00d13b6oq0xtd90e%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TASK_PORT%2522%252C%2522taskId%2522%253A%2522dev%2522%252C%2522port%2522%253A3000%252C%2522path%2522%253A%2522%252F%2522%257D%255D%252C%2522id%2522%253A%2522clniy640z00d23b6oumbd0y88%2522%252C%2522activeTabId%2522%253A%2522clniy640z00d13b6oq0xtd90e%2522%257D%252C%2522clniy640z00d03b6okgd5lt2c%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clniy640z00cy3b6ouyntzx5p%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TASK_LOG%2522%252C%2522taskId%2522%253A%2522dev%2522%257D%252C%257B%2522id%2522%253A%2522clniy640z00cz3b6ofs8ppoft%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TERMINAL%2522%252C%2522shellId%2522%253A%2522clnixe8i2000oe6jlb6ugdw6a%2522%257D%255D%252C%2522id%2522%253A%2522clniy640z00d03b6okgd5lt2c%2522%252C%2522activeTabId%2522%253A%2522clniy640z00cy3b6ouyntzx5p%2522%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Atrue%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D)

### To see that this bug does not occur if I don't use the `next-redux-wrapper` pacakge head over to [this sandbox](https://codesandbox.io/p/github/karanshah229/next-redux-wrapper-selector-issue/main?layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522clnixe8an00073b6otx8gp4f2%2522%252C%2522sizes%2522%253A%255B70%252C30%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522clnixe8an00033b6odu5afy5u%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522clnixe8an00053b6ogbkacvzr%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522clnixe8an00063b6o3nhoimic%2522%257D%255D%252C%2522sizes%2522%253A%255B100%255D%257D%255D%252C%2522sizes%2522%253A%255B60%252C40%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522clnixe8an00033b6odu5afy5u%2522%253A%257B%2522id%2522%253A%2522clnixe8an00033b6odu5afy5u%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clnixe8an00023b6o45wovm74%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252FREADME.md%2522%252C%2522view%2522%253A%2522code%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%252C%257B%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252Fsrc%252Fslices%252FcounterSlice.ts%2522%252C%2522id%2522%253A%2522clnixt8r902eo3b6o1i9vr2xx%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%252C%257B%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252Fsrc%252Fcomponents%252FAnotherComponent.tsx%2522%252C%2522id%2522%253A%2522clnixy31406v23b6or32vyms1%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%255D%252C%2522activeTabId%2522%253A%2522clnixe8an00023b6o45wovm74%2522%257D%252C%2522clnixe8an00063b6o3nhoimic%2522%253A%257B%2522id%2522%253A%2522clnixe8an00063b6o3nhoimic%2522%252C%2522activeTabId%2522%253A%2522clnixexox009l3b6o3s0awc6y%2522%252C%2522tabs%2522%253A%255B%257B%2522type%2522%253A%2522TASK_PORT%2522%252C%2522taskId%2522%253A%2522dev%2522%252C%2522port%2522%253A3000%252C%2522id%2522%253A%2522clnixexox009l3b6o3s0awc6y%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522path%2522%253A%2522%252F%2522%257D%255D%257D%252C%2522clnixe8an00053b6ogbkacvzr%2522%253A%257B%2522id%2522%253A%2522clnixe8an00053b6ogbkacvzr%2522%252C%2522activeTabId%2522%253A%2522clnixe8an00043b6om57xeuuo%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522clnixe8an00043b6om57xeuuo%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522TERMINAL%2522%252C%2522shellId%2522%253A%2522clnixe8i2000oe6jlb6ugdw6a%2522%257D%252C%257B%2522type%2522%253A%2522TASK_LOG%2522%252C%2522taskId%2522%253A%2522dev%2522%252C%2522id%2522%253A%2522clnixeuw900823b6oax48c0l7%2522%252C%2522mode%2522%253A%2522permanent%2522%257D%255D%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Atrue%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D)
